### PR TITLE
Add workflow building code and checking formatting

### DIFF
--- a/.github/workflows/components.yaml
+++ b/.github/workflows/components.yaml
@@ -1,0 +1,45 @@
+name: React Components
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  format:
+    name: Check code format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Check formatting
+        run: yarn format
+
+  build:
+    name: Build code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
Workflow consists of two jobs. The `format` job checks if formatting of
the code follows conventions used in the organization. The `build` jobs
compiles the code.
Workflow will be executed for all PRs, merges to `main` and on schedule,
at midnight (UTC). It will also be possible to trigerr the flow
manually.