### PR TITLE
Add README to the npm workflow path

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -11,6 +11,7 @@ on:
       - "package.json"
       - "yarn.lock"
       - ".github/workflows/npm.yml"
+      - "README.md"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds README file to the npm worflow path. This means that whenever we change
something to the file the library will automatically be published to npm
registry.