### PR TITLE
Fixes 2 bugs with FilterTabs Component

### DIFF
--- a/src/components/FilterTabs/index.tsx
+++ b/src/components/FilterTabs/index.tsx
@@ -1,5 +1,10 @@
 import { createContext, FC, useContext, useState } from "react"
-import { Button, ButtonGroup, useStyleConfig } from "@chakra-ui/react"
+import {
+  Button,
+  ButtonGroup,
+  ButtonGroupProps,
+  useStyleConfig,
+} from "@chakra-ui/react"
 import { FilterTabSize, FilterTabVariant } from "../../theme/FilterTab"
 
 export interface FilterTabProps {
@@ -8,7 +13,7 @@ export interface FilterTabProps {
   variant: FilterTabVariant
 }
 
-export interface FilterTabsProps {
+export interface FilterTabsProps extends ButtonGroupProps {
   variant?: FilterTabVariant
   size?: FilterTabSize
   selectedTabId?: string
@@ -68,6 +73,7 @@ export const FilterTabs: FC<FilterTabsProps> = ({
   size = "md",
   selectedTabId,
   onTabClick,
+  ...props
 }) => {
   const styles = useStyleConfig("FilterTabs", { variant })
 
@@ -76,7 +82,7 @@ export const FilterTabs: FC<FilterTabsProps> = ({
       onTabClick={onTabClick}
       selectedTabId={selectedTabId || tabs[0].tabId}
     >
-      <ButtonGroup spacing="3" size={size} sx={styles}>
+      <ButtonGroup spacing="3" size={size} sx={styles} {...props}>
         {tabs.map((tab) => {
           return (
             <FilterTab

--- a/src/components/FilterTabs/index.tsx
+++ b/src/components/FilterTabs/index.tsx
@@ -42,7 +42,12 @@ const FilterTabsProvider: FC<TabsProviderProps> = (props) => {
     <FilterTabsContext.Provider
       value={{
         selectedTabId,
-        onTabClick: props.onTabClick || setSelectedTabId,
+        onTabClick: (tabId) => {
+          if (props.onTabClick) {
+            props.onTabClick(tabId)
+          }
+          setSelectedTabId(tabId)
+        },
       }}
     >
       {props.children}


### PR DESCRIPTION
This PR fixes two bugs with the the Filter tabs component 

1. Allows the user to pass props such as `mb={4}` that will be passed to the Button group for additional styling if needed.
2. Forces the tabs to update the internal context state for the `SelectedTabId` which is needed when the selected ID is managed by the parent's state.