### PR TITLE
Adds missing props to the box label component

### DIFF
--- a/src/components/BoxLabel/index.tsx
+++ b/src/components/BoxLabel/index.tsx
@@ -1,12 +1,18 @@
 import { FC, ReactNode, useMemo } from "react"
 import { chakra, TextProps, useMultiStyleConfig } from "@chakra-ui/react"
 import { BodyLg, BodyMd, BodySm, BodyXs } from "../Typography"
-import { BoxLabelVariant, BoxLabelSize } from "../../theme/BoxLabel"
+import {
+  BoxLabelVariant,
+  BoxLabelSize,
+  BoxLabelStatus,
+} from "../../theme/BoxLabel"
 
 export interface BoxLabelProps extends TextProps {
   colorScheme?: BoxLabelVariant
   size?: BoxLabelSize
   icon?: ReactNode
+  status?: BoxLabelStatus
+  variant?: BoxLabelVariant
 }
 
 export const BoxLabel: FC<BoxLabelProps> = ({ ...props }) => {


### PR DESCRIPTION
BoxLabel was throwing a TS error for missing props:

```
  Property 'status' does not exist on type 'IntrinsicAttributes & BoxLabelProps & { children?:ReactNode; }'.
```