### PR TITLE
Fix image import

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@fontsource/inter": "^4.5.10",
     "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep#d6ec02e",
     "@rollup/plugin-commonjs": "^21.0.3",
+    "@rollup/plugin-image": "^2.1.1",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@snek-at/storybook-addon-chakra-ui": "^1.0.0-beta.1",
     "@storybook/addon-actions": "^6.4.21",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -3,6 +3,7 @@ import resolve from "@rollup/plugin-node-resolve"
 import commonjs from "@rollup/plugin-commonjs"
 import typescript from "rollup-plugin-typescript2"
 import postcss from "rollup-plugin-postcss"
+import image from "@rollup/plugin-image"
 
 const packageJson = require("./package.json")
 
@@ -35,5 +36,6 @@ export default {
     postcss({
       extensions: [".css"],
     }),
+    image(),
   ],
 }

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,7 @@
+// Adds support for importing resource files [.png, .svg, .jpeg. jpg]. Without
+// that there is an error when trying to import the images
+// More info: https://stackoverflow.com/questions/52759220/importing-images-in-typescript-react-cannot-find-module
+declare module "*.png"
+declare module "*.svg"
+declare module "*.jpeg"
+declare module "*.jpg"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2149,6 +2149,14 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
+"@rollup/plugin-image@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-image/-/plugin-image-2.1.1.tgz#898d6b59ac0025d7971ef45640ab330cb0663b0c"
+  integrity sha512-AgP4U85zuQJdUopLUCM+hTf45RepgXeTb8EJsleExVy99dIoYpt3ZlDYJdKmAc2KLkNntCDg6BPJvgJU3uGF+g==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    mini-svg-data-uri "^1.2.3"
+
 "@rollup/plugin-node-resolve@^13.1.3":
   version "13.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz#2ed277fb3ad98745424c1d2ba152484508a92d79"
@@ -8268,6 +8276,11 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-svg-data-uri@^1.2.3:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz#8ab0aabcdf8c29ad5693ca595af19dd2ead09939"
+  integrity sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Adds support for importing resource files [.png, .svg, .jpeg. jpg]. Without that there is an error when trying to import the images - `[!] (plugin rpt2) Error: /home/runner/work/components/components/src/components/AlertBox/index.tsx(11,28): semantic error TS2307: Cannot find module '../../static/images/MagicAlertIcon.png' or its corresponding type declarations.`

More info: https://stackoverflow.com/questions/52759220/importing-images-in-typescript-react-cannot-find-module