### PR TITLE
Use named export when exporting useCountdown hook

### DIFF
--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -7,7 +7,7 @@ import {
   TimeUnits,
 } from "../utils"
 
-const useCountdown = (
+export const useCountdown = (
   targetDateInUnix: number,
   addLeadingZeroes?: boolean,
   onComplete?: (targetDateInUnix: number) => void
@@ -45,5 +45,3 @@ const useCountdown = (
     seconds,
   }
 }
-
-export default useCountdown


### PR DESCRIPTION
Related to: https://github.com/threshold-network/components/pull/12

This change is required to properly export the `useCountdown` hook from the lib.
Otherwise the hook is not found since the export is not named.