### PR TITLE
Fix `FilterTabs` component

### DIFF
--- a/src/components/FilterTabs/context/FilterTabsContext.tsx
+++ b/src/components/FilterTabs/context/FilterTabsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, useContext, useState } from "react"
+import { createContext, FC, useContext, useEffect, useState } from "react"
 
 export const useFilterTabsContext = () => {
   const context = useContext(FilterTabsContext)
@@ -25,7 +25,16 @@ export interface FilterTabsProviderProps
   extends Partial<FilterTabsContextProps> {}
 
 export const FilterTabsProvider: FC<FilterTabsProviderProps> = (props) => {
-  const [selectedTabId, setSelectedTabId] = useState(props.selectedTabId || "")
+  const { selectedTabId: selectedTabIdFromProps } = props
+
+  const [selectedTabId, setSelectedTabId] = useState(
+    selectedTabIdFromProps || ""
+  )
+
+  useEffect(() => {
+    setSelectedTabId(selectedTabIdFromProps || "")
+  }, [selectedTabIdFromProps])
+
   const variant = props.variant ? props.variant : "primary"
 
   return (


### PR DESCRIPTION
We use the `selectedTabId` prop as a default value of `useState` hook. In that
case, if the `selectedTabId` prop changes the component state is not updated
because the `useState` hook is used only once not every time the props change.
We must call `setSelectedTabId` in `useEffect` hook once the `selectedTabId`
prop changes.