### PR TITLE
Adjusts border color on filter tabs

### DIFF
--- a/src/theme/FilterTab.ts
+++ b/src/theme/FilterTab.ts
@@ -24,7 +24,6 @@ export const FilterTab: ComponentStyleConfig = {
         color: mode("brand.500", "brand.100")(props),
         borderColor: mode("gray.50", "gray.300")(props),
         _hover: {
-          border: mode("1px solid black", "none")(props),
           bg: mode("#F2EDFF", "gray.700")(props),
         },
       },

--- a/src/theme/FilterTabs.ts
+++ b/src/theme/FilterTabs.ts
@@ -10,7 +10,7 @@ export const FilterTabs: ComponentStyleConfig = {
     primary: (props) => ({
       bgColor: mode("white", "gray.800")(props),
       border: "1px solid",
-      borderColor: "gray.100",
+      borderColor: mode("gray.100", "gray.700")(props),
       boxShadow: "md",
       width: "full",
     }),


### PR DESCRIPTION
The Filter tabs component was flagged in QA for having incorrect border colors:

![Screen Shot 2022-09-29 at 8 39 05 PM](https://user-images.githubusercontent.com/15269424/193178292-cbdfbde2-7f5f-4ad0-9586-278d11958c55.png)
