### PR TITLE
Use actions running on `node16`

### DIFF
--- a/.github/workflows/components.yaml
+++ b/.github/workflows/components.yaml
@@ -14,9 +14,9 @@ jobs:
     name: Check code format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "yarn"
@@ -31,9 +31,9 @@ jobs:
     name: Build code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "yarn"

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -18,9 +18,9 @@ jobs:
   npm-compile-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Node 12 has been out of support since April 2022, as a result GitHub has started the deprecation process of Node 12 for GitHub Actions. They plan to migrate all actions to run on Node16 by Summer 2023. Some of the GH Marketplace actions that we've been using in our workflows were running on `node12`, but have already published new versions running on `node16`. We're updating those actions to the latest versions.

Read more on
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.