### PR TITLE
Add links to Design System documentation & Figma

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repo contains reusable React components for Threshold Network.
 
+*For design documentation on these components, refer to the repo on Design System documentation [here](https://github.com/threshold-network/design-system-docs).*
+
+*You can also duplicate the Figma file [here](https://www.figma.com/file/zZi2fYDUjWEMPQJWAt8VWv/Threshold-DS?node-id=3436%3A24296).*
+
 ## Setup
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 This repo contains reusable React components for Threshold Network.
 
-*For design documentation on these components, refer to the repo on Design System documentation [here](https://github.com/threshold-network/design-system-docs).*
+_For design documentation on these components, refer to the repo on Design
+System documentation
+[here](https://github.com/threshold-network/design-system-docs)._
 
-*You can also duplicate the Figma file [here](https://www.figma.com/file/zZi2fYDUjWEMPQJWAt8VWv/Threshold-DS?node-id=3436%3A24296).*
+_You can also duplicate the Figma file
+[here](https://www.figma.com/file/zZi2fYDUjWEMPQJWAt8VWv/Threshold-DS?node-id=3436%3A24296)._
 
 ## Setup
 


### PR DESCRIPTION
Adds links to the design system documentation repo and adds a link to duplicate the Figma file.

Design system repo: https://github.com/threshold-network/design-system-docs

[Figma](https://www.figma.com/file/zZi2fYDUjWEMPQJWAt8VWv/Threshold-DS?node-id=3436%3A24296)